### PR TITLE
Update Ruby/Rails test versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0", 3.1, head]
+        ruby: [2.6, 2.7, "3.0", 3.1, head]
         gemfile: [rails_5_2, rails_6]
         exclude:
           - ruby: "3.0"


### PR DESCRIPTION
- Remove EOL Rubies (<3.1) from test matrix
- Remove EOL Rails versions (<6.1) from test matrix